### PR TITLE
Add Jest tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: Node.js CI
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - run: npm install
+      - run: npm test --if-present

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@
    ```
    This step generates optimized assets ready for deployment.
 
+4. **Run Tests**
+
+   ```bash
+   npm test
+   ```
+   Executes the unit test suite.
+
 ## Sample Datasets
 
 No sample datasets are included at the moment. If you add datasets, place them in a `data/` directory.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+function add(a, b) {
+  return a + b;
+}
+
+module.exports = { add };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "data-vis",
+  "version": "1.0.0",
+  "description": "1. **Install Dependencies**",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/tests/add.test.js
+++ b/tests/add.test.js
@@ -1,0 +1,5 @@
+const { add } = require('../index');
+
+test('adds numbers correctly', () => {
+  expect(add(2, 3)).toBe(5);
+});


### PR DESCRIPTION
## Summary
- set up Jest testing with a simple add() function
- document how to run tests
- configure GitHub Actions to run `npm test` on pull requests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683fd6f1086c832aa60fd9d3870c1b92