### PR TITLE
Handle Papaparse failures

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,7 +7,7 @@ import ChartConfiguration from './components/ChartConfiguration';
 import Visualization from './components/Visualization';
 
 export default function App() {
-  const { data, handleFileUpload } = useFileProcessor();
+  const { data, handleFileUpload, error } = useFileProcessor();
   const summary = useDataAnalysis(data);
   const [chartConfig, setChartConfig] = useState({ type: 'bar', x: '', y: '' });
 
@@ -15,6 +15,7 @@ export default function App() {
     <div>
       <h1>Data Visualization App</h1>
       <FileUpload onFileLoaded={handleFileUpload} />
+      {error && <p style={{ color: 'red' }}>{error}</p>}
       <DataSummary summary={summary} />
       {summary && (
         <ChartConfiguration

--- a/src/hooks/useFileProcessor.js
+++ b/src/hooks/useFileProcessor.js
@@ -3,16 +3,26 @@ import { parse } from 'papaparse';
 
 export function useFileProcessor() {
   const [data, setData] = useState(null);
+  const [error, setError] = useState(null);
 
   const handleFileUpload = (file) => {
     const reader = new FileReader();
     reader.onload = (event) => {
       const csv = event.target.result;
-      const result = parse(csv, { header: true });
-      setData(result.data);
+      try {
+        const result = parse(csv, { header: true });
+        if (result.errors && result.errors.length > 0) {
+          throw new Error(result.errors[0].message);
+        }
+        setData(result.data);
+        setError(null);
+      } catch (err) {
+        setError(err.message || 'Failed to parse file');
+        setData(null);
+      }
     };
     reader.readAsText(file);
   };
 
-  return { data, handleFileUpload };
+  return { data, handleFileUpload, error };
 }


### PR DESCRIPTION
## Summary
- wrap the Papaparse call in a try/catch block
- surface errors via the `useFileProcessor` hook
- show parsing errors in the App UI

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_6840c1633010832a9aec9fc146f0a76d