### PR TITLE
Add default column selection and reset

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useFileProcessor } from './hooks/useFileProcessor';
 import useDataAnalysis from './hooks/useDataAnalysis';
 import FileUpload from './components/FileUpload';
@@ -11,6 +11,23 @@ export default function App() {
   const summary = useDataAnalysis(data);
   const [chartConfig, setChartConfig] = useState({ type: 'bar', x: '', y: '' });
 
+  useEffect(() => {
+    if (summary && summary.columns.length >= 2) {
+      setChartConfig((prev) => {
+        if (prev.x || prev.y) return prev;
+        return { ...prev, x: summary.columns[0], y: summary.columns[1] };
+      });
+    }
+  }, [summary]);
+
+  const resetConfig = () => {
+    if (summary && summary.columns.length >= 2) {
+      setChartConfig({ type: 'bar', x: summary.columns[0], y: summary.columns[1] });
+    } else {
+      setChartConfig({ type: 'bar', x: '', y: '' });
+    }
+  };
+
   return (
     <div>
       <h1>Data Visualization App</h1>
@@ -21,6 +38,7 @@ export default function App() {
           columns={summary.columns}
           config={chartConfig}
           onChange={setChartConfig}
+          onReset={resetConfig}
         />
       )}
       {summary && <Visualization data={data} config={chartConfig} />}

--- a/src/components/ChartConfiguration.jsx
+++ b/src/components/ChartConfiguration.jsx
@@ -6,7 +6,7 @@ const chartTypes = [
   { value: 'scatter', label: 'Scatter' }
 ];
 
-export default function ChartConfiguration({ columns, config, onChange }) {
+export default function ChartConfiguration({ columns, config, onChange, onReset }) {
   if (!columns) return null;
 
   const handleSelect = (e) => {
@@ -43,6 +43,7 @@ export default function ChartConfiguration({ columns, config, onChange }) {
           ))}
         </select>
       </label>
+      <button type="button" onClick={onReset}>Reset</button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- auto-choose the first two columns for X and Y after data is analyzed
- add a Reset button in chart configuration to restore defaults

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840c1670900832a8934e406b36a269f